### PR TITLE
add note about this being obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+This cheatsheet is for **version 1** of Magit and many things have
+changed considerably in **version 2**, including the key bindings.  If
+you are using version 2 (which you should), then instead head over to
+the new [homepage](http://magit.vc), which among other things features
+a [new manual](http://magit.vc/manual/magit) and a
+[semi-official refcard](http://magit.vc/manual/magit-refcard.pdf.  If
+you are updating from version 1 to 2, then you should also read the
+[update instructions](http://magit.vc/manual/magit/Installation.html).
+
 Magit Cheatsheet
 ----------------
 magit is an emacs mode for git, and is crazy awesome. I've distilled the Magit User Manual into a command-centric cheatsheet for my own purposes. 

--- a/magit-cheatsheet.html
+++ b/magit-cheatsheet.html
@@ -109,14 +109,22 @@
 </head>
 <body>
 
-<div id="preamble">
-
-
-<div class="preamble">This is a distillation of the <a
-href="http://magit.github.com/magit/magit.html">Magit user
-manual</a>, which has more detail than this quick cheatsheet
-provides. Read the user manual! Blogpost containing materials to
-regenerate this cheatsheet from scratch <a href=
+<div class="preamble">
+<h1 class="title">THIS CHEATSHEET IS OBSOLETE</h2>
+<p>
+  This cheatsheet is for <b>version 1</b> of Magit and many things
+  have changed considerably in <b>version 2</b>, including the key
+  bindings.  If you are using version 2 (which you should), then
+  instead head over to the
+  new <a href="http://magit.vc/">homepage</a>, which among other
+  things features a <a href="http://magit.vc/manual/magit">new
+  manual</a> and
+  a <a href="http://magit.vc/manual/magit-refcard.pdf">semi-official
+  refcard</a>.  If you are updating from version 1 to 2, then you
+  should also read
+  the <a href="http://magit.vc/manual/magit/Installation.html">update
+  instructions</a>.
+</p>
 </div>
 
 <div id="content">


### PR DESCRIPTION
The note was added to the README.md and directly to the magit-cheetsheet.html (because exporting from org produced something quite different from the previous export, and I didn't want to deal with that).

---

Of course I would welcome if you could update this. But in the mean time it would be good if users who come across your cheatsheet knew that it is obsolete. (On Google it's still at position three when searching for "magit", five for "magit emacs".)
